### PR TITLE
Market endpoints

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'net-http'
+  gem 'jsonapi-serializer'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     io-console (0.6.0)
     irb (1.6.4)
       reline (>= 0.3.0)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     loofah (2.21.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -117,6 +119,8 @@ GEM
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.7.0)
+    net-http (0.3.2)
+      uri
     net-imap (0.3.4)
       date
       net-protocol
@@ -200,6 +204,7 @@ GEM
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (0.12.1)
     vcr (6.1.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
@@ -220,6 +225,8 @@ DEPENDENCIES
   faker
   faraday
   figaro
+  jsonapi-serializer
+  net-http
   pg (~> 1.1)
   pry
   puma (~> 5.0)

--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -1,0 +1,5 @@
+class Api::V0::MarketsController < ApplicationController
+  def index
+    render json: Market.all
+  end
+end

--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -1,5 +1,5 @@
 class Api::V0::MarketsController < ApplicationController
   def index
-    render json: Market.all
+    render json: MarketSerializer.new(Market.all)
   end
 end

--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -1,5 +1,23 @@
 class Api::V0::MarketsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :no_record
+  
   def index
     render json: MarketSerializer.new(Market.all)
   end
+
+  def show
+    render json: MarketSerializer.new(Market.find(params[:id]))
+  end
+
+  private
+    def no_record
+      error_message = { 
+        errors: [
+          {
+            detail: "Couldn't find Market with 'id'=#{params[:id]}"
+            }
+            ]
+          }
+      render json: error_message
+    end
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -1,4 +1,8 @@
 class Market < ApplicationRecord
   has_many :market_vendors
   has_many :vendors, through: :market_vendors
+
+  def count_of_vendors
+    vendors.count
+  end
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -2,7 +2,7 @@ class Market < ApplicationRecord
   has_many :market_vendors
   has_many :vendors, through: :market_vendors
 
-  def count_of_vendors
+  def vendor_count
     vendors.count
   end
 end

--- a/app/serializers/market_serializer.rb
+++ b/app/serializers/market_serializer.rb
@@ -1,0 +1,8 @@
+class MarketSerializer
+  include JSONAPI::Serializer
+  attributes :id, :name, :street, :city, :county, :state, :zip, :lat, :lon
+
+  attribute :vendor_count do |market|
+    market.count_of_vendors
+  end
+end

--- a/app/serializers/market_serializer.rb
+++ b/app/serializers/market_serializer.rb
@@ -1,7 +1,6 @@
 class MarketSerializer
   include JSONAPI::Serializer
-  attributes :id, 
-             :name, 
+  attributes :name, 
              :street, 
              :city, 
              :county, 

--- a/app/serializers/market_serializer.rb
+++ b/app/serializers/market_serializer.rb
@@ -1,8 +1,13 @@
 class MarketSerializer
   include JSONAPI::Serializer
-  attributes :id, :name, :street, :city, :county, :state, :zip, :lat, :lon
-
-  attribute :vendor_count do |market|
-    market.count_of_vendors
-  end
+  attributes :id, 
+             :name, 
+             :street, 
+             :city, 
+             :county, 
+             :state, 
+             :zip, 
+             :lat, 
+             :lon, 
+             :vendor_count
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   # root "articles#index"
   namespace :api do
     namespace :v0 do
-      resources :markets, only: [:index]
+      resources :markets, only: [:index, :show]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,9 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  namespace :api do
+    namespace :v0 do
+      resources :markets, only: [:index]
+    end
+  end
 end

--- a/spec/factories/market_factory.rb
+++ b/spec/factories/market_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     name { Faker::Company.name }
     street { Faker::Address.street_name }
     city { Faker::Address.city }
-    country { 'US' }
+    county { Faker::Address.country }
     state { Faker::Address.state }
     zip { Faker::Address.zip}
     lat { Faker::Address.latitude }

--- a/spec/factories/market_vendor_factory.rb
+++ b/spec/factories/market_vendor_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :market_vendor do
+    market_id {}
+    vendor_id {}
+  end
+end

--- a/spec/factories/vendor_factory.rb
+++ b/spec/factories/vendor_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :market do
+  factory :vendor do
     name { Faker::Commerce.vendor }
     description { Faker::Marketing.buzzwords }
     contact_name { Faker::Name.first_name }

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Market, type: :model do
   describe 'instance methods' do
     describe '#count_of_vendors' do
       it 'returns the number of vendors linked to a market' do
-        expect(@market1.count_of_vendors).to eq(4)
-        expect(@market2.count_of_vendors).to eq(1)
-        expect(@market3.count_of_vendors).to eq(0)
+        expect(@market1.vendor_count).to eq(4)
+        expect(@market2.vendor_count).to eq(1)
+        expect(@market3.vendor_count).to eq(0)
       end
     end
   end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -1,9 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Market, type: :model do
+  before(:each) do
+    test_data
+  end
+
   describe 'relationships' do
     it {should have_many(:market_vendors)}
     it {should have_many(:vendors).through(:market_vendors)}
   end
 
+  describe 'instance methods' do
+    describe '#count_of_vendors' do
+      it 'returns the number of vendors linked to a market' do
+        expect(@market1.count_of_vendors).to eq(4)
+        expect(@market2.count_of_vendors).to eq(1)
+        expect(@market3.count_of_vendors).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -5,5 +5,4 @@ RSpec.describe Vendor, type: :model do
     it {should have_many(:market_vendors)}
     it {should have_many(:markets).through(:market_vendors)}
   end
-
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,24 @@
+def test_data
+  @market1 = create(:market)
+  @market2 = create(:market)
+  @market3 = create(:market)
+  @market4 = create(:market)
+
+  @vendor1 = create(:vendor)
+  @vendor2 = create(:vendor)
+  @vendor3 = create(:vendor)
+  @vendor4 = create(:vendor)
+  @vendor5 = create(:vendor)
+
+  @mv1 = create(:market_vendor, market: @market1, vendor: @vendor1)
+  @mv2 = create(:market_vendor, market: @market1, vendor: @vendor2)
+  @mv3 = create(:market_vendor, market: @market1, vendor: @vendor3)
+  @mv4 = create(:market_vendor, market: @market1, vendor: @vendor4)
+  @mv5 = create(:market_vendor, market: @market2, vendor: @vendor1)
+end
+
+
+
 require 'simplecov'
 SimpleCov.start
 # This file is copied to spec/ when you run 'rails generate rspec:install'

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -10,9 +10,33 @@ RSpec.describe 'Markets API' do
       get '/api/v0/markets'
 
       json = JSON.parse(response.body, symbolize_names: true)
-      require 'pry'; binding.pry
-      expect(json).to be_an Array
-      expect(json.count).to eq(5)
+      
+      expect(json[:data]).to be_an Array
+      expect(json[:data].count).to eq(5)
+      json[:data].each do |market|
+        expect(market).to have_key(:id)
+        expect(market).to have_key(:type)
+        expect(market[:attributes]).to be_a Hash
+        expect(market[:attributes]).to have_key(:name)
+        expect(market[:attributes]).to have_key(:street)
+        expect(market[:attributes]).to have_key(:city)
+        expect(market[:attributes]).to have_key(:county)
+        expect(market[:attributes]).to have_key(:state)
+        expect(market[:attributes]).to have_key(:zip)
+        expect(market[:attributes]).to have_key(:lat)
+        expect(market[:attributes]).to have_key(:lon)
+        expect(market[:attributes]).to have_key(:vendor_count)
+
+        expect(market[:attributes][:name]).to be_a String
+        expect(market[:attributes][:street]).to be_a String
+        expect(market[:attributes][:city]).to be_a String
+        expect(market[:attributes][:county]).to be_a String
+        expect(market[:attributes][:state]).to be_a String
+        expect(market[:attributes][:zip]).to be_a String
+        expect(market[:attributes][:lat]).to be_a String
+        expect(market[:attributes][:lon]).to be_a String
+        expect(market[:attributes][:vendor_count]).to be_an Integer
+      end
     end
   end
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Markets API' do
       get '/api/v0/markets'
 
       expect(response).to be_successful
-      
+
       json = JSON.parse(response.body, symbolize_names: true)
       
       expect(json[:data]).to be_an Array
@@ -41,6 +41,56 @@ RSpec.describe 'Markets API' do
         expect(market[:attributes][:lon]).to be_a String
         expect(market[:attributes][:vendor_count]).to be_an Integer
       end
+    end
+  end
+
+  describe 'Sends a single market' do
+    it 'If a valid request it sends the market data' do
+      get "/api/v0/markets/#{@market1.id}"
+      
+      expect(response).to be_successful
+      
+      json = JSON.parse(response.body, symbolize_names: true)
+      
+      expect(json[:data]).to be_a Hash
+      
+      expect(json[:data]).to have_key(:id)
+      expect(json[:data]).to have_key(:type)
+      expect(json[:data]).to have_key(:attributes)
+      expect(json[:data][:attributes]).to be_a Hash
+      expect(json[:data][:attributes]).to have_key(:name)
+      expect(json[:data][:attributes]).to have_key(:street)
+      expect(json[:data][:attributes]).to have_key(:city)
+      expect(json[:data][:attributes]).to have_key(:county)
+      expect(json[:data][:attributes]).to have_key(:state)
+      expect(json[:data][:attributes]).to have_key(:zip)
+      expect(json[:data][:attributes]).to have_key(:lat)
+      expect(json[:data][:attributes]).to have_key(:lon)
+      expect(json[:data][:attributes]).to have_key(:vendor_count)
+      
+      expect(json[:data][:attributes][:name]).to eq(@market1.name)
+      expect(json[:data][:attributes][:street]).to eq(@market1.street)
+      expect(json[:data][:attributes][:city]).to eq(@market1.city)
+      expect(json[:data][:attributes][:county]).to eq(@market1.county)
+      expect(json[:data][:attributes][:state]).to eq(@market1.state)
+      expect(json[:data][:attributes][:zip]).to eq(@market1.zip)
+      expect(json[:data][:attributes][:lat]).to eq(@market1.lat)
+      expect(json[:data][:attributes][:lon]).to eq(@market1.lon)
+      expect(json[:data][:attributes][:vendor_count]).to eq(@market1.vendor_count)
+    end
+
+    it 'If an invalid request, returns an error message and 404' do
+      get "/api/v0/markets/#{1000000}"
+
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json).to have_key(:errors)
+      expect(json[:errors]).to be_an Array
+      expect(json[:errors][0]).to be_a Hash
+      expect(json[:errors][0]).to have_key(:detail)
+      expect(json[:errors][0][:detail]).to be_a String
+      expect(json[:errors][0][:detail]).to eq("Couldn't find Market with 'id'=1000000")
+
     end
   end
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -2,20 +2,24 @@ require 'rails_helper'
 
 RSpec.describe 'Markets API' do
   before(:each) do
-    create_list(:market, 5)
+    test_data
   end
 
   describe 'Sends markets' do
     it 'Sends a list of all markets' do
       get '/api/v0/markets'
 
+      expect(response).to be_successful
+      
       json = JSON.parse(response.body, symbolize_names: true)
       
       expect(json[:data]).to be_an Array
-      expect(json[:data].count).to eq(5)
+      expect(json[:data].count).to eq(4)
+
       json[:data].each do |market|
         expect(market).to have_key(:id)
         expect(market).to have_key(:type)
+        expect(market).to have_key(:attributes)
         expect(market[:attributes]).to be_a Hash
         expect(market[:attributes]).to have_key(:name)
         expect(market[:attributes]).to have_key(:street)

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'Markets API' do
+  before(:each) do
+    create_list(:market, 5)
+  end
+
+  describe 'Sends markets' do
+    it 'Sends a list of all markets' do
+      get '/api/v0/markets'
+
+      json = JSON.parse(response.body, symbolize_names: true)
+      require 'pry'; binding.pry
+      expect(json).to be_an Array
+      expect(json.count).to eq(5)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds both endpoints for Markets
/api/v0/markets and /api/v0/markets/:id
error handling is present but will more than likely need to be refactored since it's a little smelly. 